### PR TITLE
(meta)package.xml should not depend on catkin

### DIFF
--- a/executive_smach/package.xml
+++ b/executive_smach/package.xml
@@ -13,8 +13,6 @@
   <author>Jonathan Bohren</author>
   <author>Wim Meeussen</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <run_depend>smach</run_depend>
   <run_depend>emach_ros</run_depend>
   <run_depend>smach_msgs</run_depend>


### PR DESCRIPTION
Doing so makes this page go crazy: http://ros.org/wiki/catkin
