### PR TITLE
correcting get_active_states()

### DIFF
--- a/smach/src/smach/concurrence.py
+++ b/smach/src/smach/concurrence.py
@@ -1,4 +1,3 @@
-
 import threading
 import traceback
 import copy
@@ -373,7 +372,7 @@ class Concurrence(smach.container.Container):
         self.userdata.update(userdata)
 
     def get_active_states(self):
-        return [label for (label,outcome) in ((k,self._child_outcomes[k]) in self._child_outcomes) if outcome is None]
+        return [label for (label,outcome) in ((k,self._child_outcomes[k]) for k in self._child_outcomes) if outcome is None]
 
     def get_internal_edges(self):
         int_edges = []


### PR DESCRIPTION
It was missing 'for k' in the get_active_states.

```
Traceback (most recent call last):
  File "/home/dwlee/rocon_ws/src/rocon_taskcoordinator/task_master/task_manager/scripts/cafe_manager.py", line 863, in <module>
    main()
  File "/home/dwlee/rocon_ws/src/rocon_taskcoordinator/task_master/task_manager/scripts/cafe_manager.py", line 850, in main
    sis.start() 
  File "/home/dwlee/rocon_ws/src/executive_smach/smach_ros/src/smach_ros/introspection.py", line 274, in start
    self.construct(self._server_name, self._state, self._path)
  File "/home/dwlee/rocon_ws/src/executive_smach/smach_ros/src/smach_ros/introspection.py", line 295, in construct
    proxy._publish_status("Initial state")
  File "/home/dwlee/rocon_ws/src/executive_smach/smach_ros/src/smach_ros/introspection.py", line 220, in _publish_status
    self._container.get_active_states(),
  File "/home/dwlee/rocon_ws/src/executive_smach/smach/src/smach/concurrence.py", line 376, in get_active_states
    return [label for (label,outcome) in ((k,self._child_outcomes[k]) in self._child_outcomes) if outcome is None]
NameError: global name 'k' is not defined

```
