### PR TITLE
Missing package.xml and other catkin-generated files in binary packages

### DIFF
--- a/smach/CMakeLists.txt
+++ b/smach/CMakeLists.txt
@@ -19,5 +19,7 @@ else()
   find_package(catkin REQUIRED COMPONENTS)
 
   catkin_python_setup()
+
+  catkin_package()
   
 endif()

--- a/smach_ros/CMakeLists.txt
+++ b/smach_ros/CMakeLists.txt
@@ -18,4 +18,6 @@ else()
 
   catkin_python_setup()
 
+  catkin_package(CATKIN_DEPENDS rospy rostopic std_msgs std_srvs actionlib actionlib_msgs smach smach_msgs)
+
 endif()


### PR DESCRIPTION
The packages smach and smach_ros do not install a package.xml file in ROS hydro and therefore cannot be found by dependent packages. catkin requires a call to the catkin_package() macro (or catkin_metapackage) in each package's CMakeLists.txt (see http://www.ros.org/wiki/catkin/CMakeLists.txt for reference). catkin_package() installs the package.xml and some other files to `${CMAKE_INSTALL_PREFIX}/share/PACKAGE_NAME`.

This bug also affects installed catkin-builds in groovy, but the released version seems to use the rosbuild variant only.
