### PR TITLE
make ServiceState more robust to termination while waiting for service

### DIFF
--- a/smach_ros/src/smach_ros/service_state.py
+++ b/smach_ros/src/smach_ros/service_state.py
@@ -115,11 +115,14 @@ class ServiceState(smach.State):
 
         # Make sure we're connected to the service
         try:
-            while not rospy.is_shutdown() and self._proxy is None:
+            while self._proxy is None:
                 if self.preempt_requested():
                     rospy.loginfo("Preempting while waiting for service '%s'." % self._service_name)
                     self.service_preempt()
                     return 'preempted'
+                if rospy.is_shutdown():
+                    rospy.loginfo("Shutting down while waiting for service '%s'." % self._service_name)
+                    return 'aborted'
                 try:
                     rospy.wait_for_service(self._service_name,1.0)
                     self._proxy = rospy.ServiceProxy(self._service_name, self._service_spec)


### PR DESCRIPTION
Previously, control flow could "escape" from the while loop and try-catch block if the timing of the node shutdown was right.

If that happened, the ServiceState attempted to call the uninitialized proxy, causing a crash.
