### PR TITLE
Fix is_running behaviour in case of exception in the state

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -353,16 +353,18 @@ class StateMachine(smach.container.Container):
             # Initialize container outcome
             container_outcome = None
 
-            # Step through state machine
-            while container_outcome is None and self._is_running and not smach.is_shutdown():
-                # Update the state machine
-                container_outcome = self._update_once()
+            try:
+                # Step through state machine
+                while container_outcome is None and self._is_running and not smach.is_shutdown():
+                    # Update the state machine
+                    container_outcome = self._update_once()
 
-            # Copy output keys
-            self._copy_output_keys(self.userdata, parent_ud)
+                # Copy output keys
+                self._copy_output_keys(self.userdata, parent_ud)
 
-            # We're no longer running
-            self._is_running = False
+            finally:
+                # We're no longer running
+                self._is_running = False
 
         return container_outcome
 

--- a/smach_ros/test/state_machine.py
+++ b/smach_ros/test/state_machine.py
@@ -161,6 +161,23 @@ class TestStateMachine(unittest.TestCase):
 
         assert outcome == 'succeeded'
 
+    def test_exception(self):
+        class ErrorState(State):
+            """State falls with exception"""
+            def __init__(self):
+                State.__init__(self, ['done'])
+            def execute(self, ud):
+                raise Exception('Test exception')
+
+        sm = StateMachine(['done'])
+        with sm:
+            StateMachine.add('ERROR', ErrorState())
+
+        with self.assertRaises(InvalidUserCodeError):
+            sm.execute()
+
+        assert sm.is_running() == False  # test running flag lowered
+
 def main():
     rospy.init_node('state_machine_test',log_level=rospy.DEBUG)
     rostest.rosrun('smach', 'state_machine_test', TestStateMachine)


### PR DESCRIPTION
As I mentioned in #47, `StateMachine.is_running()` returns `True` even if user's state has terminated with an exception.

I fixed this for `StateMachine` and `Sequence` containers.

However, I did not fix it for `Iterator` and `Concurrence` containers as:
1. `Iterator` and `Concurrence` lack `is_running` method (only `_is_running` field exists).
2. `Iterator` is not unit tested at all yet.
