### PR TITLE
Executing an empty Concurrence container hangs forever

### DIFF
--- a/smach/src/smach/concurrence.py
+++ b/smach/src/smach/concurrence.py
@@ -197,6 +197,10 @@ class Concurrence(smach.container.Container):
         """Overridden execute method.
         This starts all the threads.
         """
+        # Check if any states added
+        if len(self._states) == 0:
+            raise smach.InvalidStateError("No states was added to concurrence")
+
         # Clear the ready event
         self._ready_event.clear()
         

--- a/smach_ros/test/concurrence.py
+++ b/smach_ros/test/concurrence.py
@@ -122,6 +122,13 @@ class TestStateMachine(unittest.TestCase):
         assert cc.userdata.a == 'A'
         assert cc.userdata.b == 'A'
 
+    def test_empty_concurrence(self):
+        """Test behavior of a container with no states"""
+        cc = Concurrence(['done'], default_outcome='done')
+
+        with self.assertRaises(InvalidStateError):
+            cc.execute()
+
 def main():
     rospy.init_node('concurrence_test',log_level=rospy.DEBUG)
     rostest.rosrun('smach', 'concurrence_test', TestStateMachine)


### PR DESCRIPTION
Let's say one have some code like:

```python
cc = Concurrence(['foo'], default_outcome='foo')

with cc:
    if add_bar:
        Concurrence.add('bar', Bar())
    if add_baz:
        Concurrence.add('baz', Baz())
cc = execute()
```

If both conditions are negative, the `execute` method will hang forever. I guess, this is pretty unexpected and confusing behaviour, and may cause strange bugs.

I propose to raise an exception in such situations.