### PR TITLE
Typo set_shutdown_cb() --> set_shutdown_check()

### DIFF
--- a/smach/src/smach/util.py
+++ b/smach/src/smach/util.py
@@ -1,35 +1,38 @@
-
 import smach
-import threading
 
+__all__ = ['is_shutdown', 'set_shutdown_check',
+           'cb_interface', 'has_smach_interface', 'CBInterface']
 
-__all__ = ['is_shutdown','set_shutdown_cb',\
-        'cb_interface','has_smach_interface','CBInterface']
 
 def is_shutdown():
     return False
 
+
 def set_shutdown_check(cb):
     smach.is_shutdown = cb
 
+
 def has_smach_interface(obj):
     """Returns True if the object has SMACH interface accessors."""
-    return hasattr(obj,'get_registered_input_keys')\
-            and hasattr(obj,'get_registered_output_keys')\
-            and hasattr(obj,'get_registered_outcomes')
+    return (hasattr(obj, 'get_registered_input_keys') and
+            hasattr(obj, 'get_registered_output_keys') and
+            hasattr(obj, 'get_registered_outcomes'))
+
 
 # Callback decorator for describing userdata
 class cb_interface(object):
-    def __init__(self, outcomes=[], input_keys=[], output_keys=[]):
-        self._outcomes = outcomes
-        self._input_keys = input_keys
-        self._output_keys = output_keys
-    
+    def __init__(self, outcomes=None, input_keys=None, output_keys=None):
+        self._outcomes = outcomes or []
+        self._input_keys = input_keys or []
+        self._output_keys = output_keys or []
+
     def __call__(self, cb):
         return CBInterface(cb, self._outcomes, self._input_keys, self._output_keys)
+
+
 class CBInterface(object):
     """Decorator to describe the extension of a state's SMACH userdata and outcome interface.
-    
+
     Some SMACH states can be extended with the use of user callbacks. Since
     the SMACH interface and SMACH userdata are strictly controlled, the ways in
     which these callbacks interact with SMACH must be delcared. This decorator
@@ -54,7 +57,12 @@ class CBInterface(object):
     >>>     ud.processed_res = data
 
     """
-    def __init__(self, cb, outcomes=[], input_keys=[], output_keys=[], io_keys=[]):
+    def __init__(self, cb, outcomes=None, input_keys=None, output_keys=None,
+                 io_keys=None):
+        outcomes = outcomes or []
+        input_keys = input_keys or []
+        output_keys = output_keys or []
+        io_keys = io_keys or []
         """Describe callback SMACH interface.
 
         @type outcomes: array of strings
@@ -62,7 +70,7 @@ class CBInterface(object):
 
         @type input_keys: array of strings
         @param input_keys: The userdata keys from which this state might read
-        at runtime. 
+        at runtime.
 
         @type output_keys: array of strings
         @param output_keys: The userdata keys to which this state might write
@@ -86,17 +94,18 @@ class CBInterface(object):
     def __call__(self, *args, **kwargs):
         return self._cb(*args, **kwargs)
 
-    ### SMACH Interface API
+    # SMACH Interface API
     def get_registered_input_keys(self):
         """Get a tuple of registered input keys."""
         return tuple(self._input_keys)
+
     def get_registered_output_keys(self):
         """Get a tuple of registered output keys."""
         return tuple(self._output_keys)
+
     def get_registered_outcomes(self):
         """Get a list of registered outcomes.
         @rtype: tuple of string
         @return: Tuple of registered outcome strings.
         """
         return tuple(self._outcomes)
-


### PR DESCRIPTION
$ __python2 -m flake8 . --count --select=E9,F821,F822,F823 --show-source --statistics__
```
./smach/src/smach/util.py:6:1: F822 undefined name 'set_shutdown_cb' in __all__
__all__ = ['is_shutdown','set_shutdown_cb',\
^
1     F822 undefined name 'set_shutdown_cb' in __all__
```

* In `__all__` the function __set_shutdown_check()__ was mistakenly typed as __set_shutdown_cb()__.
* Remove unused import
* Make changes to avoid [Mutable Default Arguments](http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments)
* Misc PEP8 cleanup

