### PR TITLE
Fixes issue with response_slots when action goal is lost

### DIFF
--- a/smach_ros/src/smach_ros/simple_action_state.py
+++ b/smach_ros/src/smach_ros/simple_action_state.py
@@ -361,8 +361,10 @@ class SimpleActionState(State):
         if self._result_key is not None:
             ud[self._result_key] = self._goal_result
 
-        for key in self._result_slots:
-            ud[key] = getattr(self._goal_result, key)
+        # Goal might be None, for instance if goal was LOST.
+        if self._goal_result is not None:
+            for key in self._result_slots:
+                ud[key] = getattr(self._goal_result, key)
 
         # Check status
         if self._status == SimpleActionState.INACTIVE:


### PR DESCRIPTION
SimpleActionState would crash when trying to extract result_slots after
goal was lost since the `_goal_result` would be `None`. This fix simply
checks if the `_goal_result` property is not `None` before trying to
extract result_slots.

Fixes #63 