### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/smach/src/smach/concurrence.py
+++ b/smach/src/smach/concurrence.py
@@ -244,7 +244,7 @@ class Concurrence(smach.container.Container):
 
         # Wait for all states to terminate
         while not smach.is_shutdown():
-            if all([not t.isAlive() for t in self._threads.values()]):
+            if all([not t.is_alive() for t in self._threads.values()]):
                 break
             self._done_cond.acquire()
             self._done_cond.wait(0.1)


### PR DESCRIPTION
Thread.isAlive is removed on Python 3.9.
Thread.is_alive is available since Python 2.6.
ref: https://docs.python.org/2/library/threading.html#threading.Thread.isAlive