### PR TITLE
set_initial_state: set current_state to initial state

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -428,9 +428,13 @@ class StateMachine(smach.container.Container):
 
         with self._state_executing_lock:
             # Set initial state
-            self._set_current_state(self._initial_state_label)
-            # Call start callbacks
-            self.call_start_cbs()
+            if self._initial_state_label not in self._states:
+                smach.logwarn("Try to set inital state '%s', but it does not exist. Available states are: %s" %
+                              (self._initial_state_label, list(self._states.keys())))
+            else:
+                self._set_current_state(self._initial_state_label)
+                # Call start callbacks
+                self.call_start_cbs()
 
     def get_active_states(self):
         return [str(self._current_label)]

--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -1,6 +1,7 @@
 
 import threading
 import traceback
+import time
 from contextlib import contextmanager
 
 import smach
@@ -41,6 +42,7 @@ class StateMachine(smach.container.Container):
         
         # Properties
         self._state_transitioning_lock = threading.Lock()
+        self._state_executing_lock = threading.Lock()
 
         # Current state of the state machine
         self._is_running = False # True when a goal has been dispatched to and accepted by the state machine
@@ -356,7 +358,10 @@ class StateMachine(smach.container.Container):
             # Step through state machine
             while container_outcome is None and self._is_running and not smach.is_shutdown():
                 # Update the state machine
-                container_outcome = self._update_once()
+                with self._state_executing_lock:
+                    container_outcome = self._update_once()
+                # let's set_initial_state to update status
+                time.sleep(0.01)
 
             # Copy output keys
             self._copy_output_keys(self.userdata, parent_ud)
@@ -420,6 +425,12 @@ class StateMachine(smach.container.Container):
             self._initial_state_label = initial_states[0]
         # Set local userdata
         self.userdata.update(userdata)
+
+        with self._state_executing_lock:
+            # Set initial state
+            self._set_current_state(self._initial_state_label)
+            # Call start callbacks
+            self.call_start_cbs()
 
     def get_active_states(self):
         return [str(self._current_label)]


### PR DESCRIPTION
Does anyone know how to use the `Set as initialState' button in `smach_viewer` or has it ever worked?

 This button is used to issue `~/smach/container_init` and executes 

https://github.com/ros/executive_smach/blob/31cc55743431f48e37ee71d26acd5833ebd3753e/smach/src/smach/state_machine.py#L410-L422

but it only updates `_initial_state_label`, which appears to have no effect on the content. I thought this feature used to work and stopped working at some point, but the first commit https://github.com/ros/executive_smach/commit/88ce8049e6d5d0f52ad59134b60026def0218041, but it doesn't seem to be working. If anyone has saved the code prior to this, please let me know.

This PR allows you to force the initial state by clocking this button, see https://github.com/eacousineau/executive_smach_tutorials/blob/854024cc2bbed1ebf90181bef2a7086beca82b24/examples/state_machine_simple_introspection.py for an example.


https://user-images.githubusercontent.com/493276/209649737-5aa4c219-a0b1-481d-a211-bf529aa06ff4.mp4

