### PR TITLE
2.5.1

### DIFF
--- a/executive_smach/CHANGELOG.rst
+++ b/executive_smach/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package executive_smach
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.5.1 (2023-02-15)
+------------------
+
 2.5.0 (2020-05-14)
 ------------------
 * Python 3 compatibility `#71 <https://github.com/ros/executive_smach/issues/71>`_

--- a/executive_smach/package.xml
+++ b/executive_smach/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>executive_smach</name>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <description>
     This metapackage depends on the SMACH library and ROS SMACH integration
     packages.

--- a/smach/CHANGELOG.rst
+++ b/smach/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package smach
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.5.1 (2023-02-15)
+------------------
+* Fix: state machines cannot be pickled `#86 <https://github.com/ros/executive_smach/issues/86>`  
+* Fix: Python 3.9 compatibility  `#82 <https://github.com/ros/executive_smach/issues/82>`
+* Typo
+
 2.5.0 (2020-05-14)
 ------------------
 * Python 3 compatibility `#71 <https://github.com/ros/executive_smach/issues/71>`_

--- a/smach/package.xml
+++ b/smach/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>smach</name>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <description>
     SMACH is a task-level architecture for rapidly creating complex robot
     behavior. At its core, SMACH is a ROS-independent Python library to build

--- a/smach_msgs/CHANGELOG.rst
+++ b/smach_msgs/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package smach_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.5.1 (2023-02-15)
+------------------
+
 2.5.0 (2020-05-14)
 ------------------
 * Python 3 compatibility `#71 <https://github.com/ros/executive_smach/issues/71>`_

--- a/smach_msgs/package.xml
+++ b/smach_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>smach_msgs</name>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <description>
     this package contains a set of messages that are used by the introspection
     interfaces for smach.

--- a/smach_ros/CHANGELOG.rst
+++ b/smach_ros/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package smach_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.5.1 (2023-02-15)
+------------------
+* Fix: response_slots when action goal is lost `#64 <https://github.com/ros/executive_smach/issues/64>`  
+* Fix: Typos
+
 2.5.0 (2020-05-14)
 ------------------
 * Python 3 compatibility `#71 <https://github.com/ros/executive_smach/issues/71>`_

--- a/smach_ros/package.xml
+++ b/smach_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>smach_ros</name>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <description>
     The smach_ros package contains extensions for the SMACH library to
     integrate it tightly with ROS.  For example, SMACH-ROS can call


### PR DESCRIPTION
Addresses https://github.com/ros/executive_smach/issues/95

# Review items
- [x] Target branch: `noetic-devel`
- [x] CI passing
