### PR TITLE
fix SyntaxWarning 'is not' when checking for equality

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -73,7 +73,7 @@ class StateMachine(smach.container.Container):
 
     ### Getter and Setter to allow pickling and unpickling state machines
     def __getstate__(self):
-        return {k:v for (k, v) in self.__dict__.items() if k is not "_state_transitioning_lock"}
+        return {k:v for (k, v) in self.__dict__.items() if k != "_state_transitioning_lock"}
 
     def __setstate__(self, d):
         self.__dict__ = d


### PR DESCRIPTION
When building this package on ubuntu 20.04 the following warning gets reported by Python:
```
.../lib/python3/dist-packages/smach/state_machine.py:76: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```