### PR TITLE
3.0.0

### DIFF
--- a/executive_smach/CHANGELOG.rst
+++ b/executive_smach/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package executive_smach
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2023-06-12)
+------------------
+* ROS2-ified. `#101 <https://github.com/ros/executive_smach/issues/101>`_
+
 2.5.1 (2023-02-15)
 ------------------
 

--- a/executive_smach/package.xml
+++ b/executive_smach/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>executive_smach</name>
-  <version>2.5.1</version>
+  <version>3.0.0</version>
   <description>
     This metapackage depends on the SMACH library and ROS SMACH integration
     packages.

--- a/smach/CHANGELOG.rst
+++ b/smach/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package smach
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2023-06-12)
+------------------
+* ROS2-ified. `#101 <https://github.com/ros/executive_smach/issues/101>`_
+* Contributors: DeepX Inc., bsteenput
+  
 2.5.1 (2023-02-15)
 ------------------
 * Fix: state machines cannot be pickled `#86 <https://github.com/ros/executive_smach/issues/86>`  

--- a/smach/package.xml
+++ b/smach/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>smach</name>
-  <version>2.5.1</version>
+  <version>3.0.0</version>
   <description>
     SMACH is a task-level architecture for rapidly creating complex robot
     behavior. At its core, SMACH is a ROS-independent Python library to build

--- a/smach/setup.py
+++ b/smach/setup.py
@@ -7,7 +7,7 @@ package_name = 'smach'
 
 setup(
     name=package_name,
-    version='2.0.1',
+    version='3.0.0',
     packages=[package_name],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/smach_msgs/CHANGELOG.rst
+++ b/smach_msgs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package smach_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2023-06-12)
+------------------
+* ROS2-ified. `#101 <https://github.com/ros/executive_smach/issues/101>`_
+
 2.5.1 (2023-02-15)
 ------------------
 

--- a/smach_msgs/package.xml
+++ b/smach_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>smach_msgs</name>
-  <version>2.5.1</version>
+  <version>3.0.0</version>
   <description>
     this package contains a set of messages that are used by the introspection
     interfaces for smach.

--- a/smach_ros/CHANGELOG.rst
+++ b/smach_ros/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package smach_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2023-06-12)
+------------------
+* ROS2-ified. `#101 <https://github.com/ros/executive_smach/issues/101>`_
+
 2.5.1 (2023-02-15)
 ------------------
 * Fix: response_slots when action goal is lost `#64 <https://github.com/ros/executive_smach/issues/64>`  

--- a/smach_ros/package.xml
+++ b/smach_ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>smach_ros</name>
-  <version>2.5.1</version>
+  <version>3.0.0</version>
   <description>
     The smach_ros package contains extensions for the SMACH library to
     integrate it tightly with ROS.  For example, SMACH-ROS can call

--- a/smach_ros/setup.py
+++ b/smach_ros/setup.py
@@ -7,7 +7,7 @@ package_name = 'smach_ros'
 
 setup(
     name=package_name,
-    version='2.0.1',
+    version='3.0.0',
     packages=[package_name],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
Good'ol `catkin_generate_changelog` and `catkin_prepare_release` bash commands are still doing great job for `ament`-packages!