### PR TITLE
Fix #92

### DIFF
--- a/smach/src/smach/concurrence.py
+++ b/smach/src/smach/concurrence.py
@@ -193,7 +193,7 @@ class Concurrence(smach.container.Container):
         return state
 
     ### State interface
-    def execute(self, parent_ud = smach.UserData()):
+    def execute(self, parent_ud = None):
         """Overridden execute method.
         This starts all the threads.
         """

--- a/smach/src/smach/iterator.py
+++ b/smach/src/smach/iterator.py
@@ -135,7 +135,7 @@ class Iterator(smach.container.Container):
         self._final_outcome_map = final_outcome_map
 
     ### State interface
-    def execute(self, parent_ud):
+    def execute(self, parent_ud = None):
         self._is_running = True
 
         # Copy input keys

--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -321,7 +321,7 @@ class StateMachine(smach.container.Container):
         return None
 
     ### State Interface
-    def execute(self, parent_ud = smach.UserData()):
+    def execute(self, parent_ud = None):
         """Run the state machine on entry to this state.
         This will set the "closed" flag and spin up the execute thread. Once
         this flag has been set, it will prevent more states from being added to


### PR DESCRIPTION
This should fix issue #92. 

The issue was that `parent_ud` was initialised as default parameter to an empty `UserData` instance. The parameter was only used in the `_copy_input_keys` and copy_output_keys`. Both methods were testing for None instead of empty userdata, and this was generating some errors when input data keys were set before the start of the State Machine (as described in the issue).

Also added the default None initialisation in the iterator container, for consistency (it didn't have any default parameter).