### PR TITLE
Fix Syntax Warning in Python 3.8

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -73,7 +73,7 @@ class StateMachine(smach.container.Container):
 
     ### Getter and Setter to allow pickling and unpickling state machines
     def __getstate__(self):
-        return {k:v for (k, v) in self.__dict__.items() if k is not "_state_transitioning_lock"}
+        return {k:v for (k, v) in self.__dict__.items() if k != "_state_transitioning_lock"}
 
     def __setstate__(self, d):
         self.__dict__ = d


### PR DESCRIPTION
While preparing PR #107 to fix #92 I found that I was getting a Syntax Warning at the start of the node. This was happening sometimes (not sure why it was not always, but quite often).

The Syntax Warning is quite clear:
```
executive_smach/smach/src/smach/state_machine.py:76: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  return {k:v for (k, v) in self.__dict__.items() if k is not "_state_transitioning_lock"}
```

And seems to come from Python 3.8 (default in Ubuntu 20.04), as stated in the [release docs](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior):

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue?@action=redirect&bpo=34850).)

This PR should fix it.