### PR TITLE
Fix: Buildfarm issue https://github.com/ros/executive_smach/issues/111

### DIFF
--- a/executive_smach/package.xml
+++ b/executive_smach/package.xml
@@ -7,7 +7,7 @@
     This metapackage depends on the SMACH library and ROS SMACH integration
     packages.
   </description>
-  <maintainer email="gm130s@gmail.com">Isaac I. Y. Saito</maintainer>
+  <maintainer email="iisaac.saito@gmail.com">Isaac Saito</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/smach</url>

--- a/smach/package.xml
+++ b/smach/package.xml
@@ -11,7 +11,7 @@
     maintainable and modular code.
   </description>
 
-  <maintainer email="gm130s@gmail.com">Isaac I. Y. Saito</maintainer>
+  <maintainer email="iisaac.saito@gmail.com">Isaac Saito</maintainer>
   <license>BSD</license>
 
   <author>Jonathan Bohren</author>

--- a/smach_msgs/CMakeLists.txt
+++ b/smach_msgs/CMakeLists.txt
@@ -3,9 +3,7 @@ cmake_minimum_required(VERSION 3.22)
 project(smach_msgs)
 
 set(AMENT_DEPS
-  ament_cmake
-  ament_cmake_flake8
-  ament_cmake_pep257)
+  ament_cmake)
 foreach(dep IN ITEMS ${AMENT_DEPS})
   find_package(${dep} REQUIRED)
 endforeach()

--- a/smach_msgs/package.xml
+++ b/smach_msgs/package.xml
@@ -8,7 +8,7 @@
     interfaces for smach.
   </description>
 
-  <maintainer email="gm130s@gmail.com">Isaac I. Y. Saito</maintainer>
+  <maintainer email="iisaac.saito@gmail.com">Isaac Saito</maintainer>
   <license>BSD</license>
 
   <author>Jonathan Bohren</author>

--- a/smach_msgs/package.xml
+++ b/smach_msgs/package.xml
@@ -16,6 +16,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_cppcheck</buildtool_depend>
+  <!-- ament_cmake_{flake8, pep257} are added to workaround https://github.com/ros2/rosidl_python/issues/198 -->
+  <buildtool_depend>ament_cmake_flake8</buildtool_depend>
+  <buildtool_depend>ament_cmake_pep257</buildtool_depend>  
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>

--- a/smach_msgs/package.xml
+++ b/smach_msgs/package.xml
@@ -26,8 +26,6 @@
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint</test_depend>
 


### PR DESCRIPTION
# Issue to be aimed at

- Closes https://github.com/ros/executive_smach/issues/111

# Changes 
- Removing a dependency on `flake8`, which is depended but not used.

# Review items
- [x] Build locally passes.
