### PR TITLE
Fix: Correct literal comparison syntax

### DIFF
--- a/smach/src/smach/state_machine.py
+++ b/smach/src/smach/state_machine.py
@@ -73,7 +73,7 @@ class StateMachine(smach.container.Container):
 
     ### Getter and Setter to allow pickling and unpickling state machines
     def __getstate__(self):
-        return {k:v for (k, v) in self.__dict__.items() if k is not "_state_transitioning_lock"}
+        return {k:v for (k, v) in self.__dict__.items() if k != "_state_transitioning_lock"}
 
     def __setstate__(self, d):
         self.__dict__ = d


### PR DESCRIPTION
A comparison to a literal was made with `is not`, causing a `SyntaxWarning`. This was changed to use the comparison operator `!=`.