### PR TITLE
Update/introspection nodes

### DIFF
--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -24,14 +24,6 @@ STRUCTURE_TOPIC = '/smach/container_structure'
 class IntrospectionClient(Node):
     def __init__(self, node_name='introspection_client', **kwargs):
         Node.__init__(self, node_name, **kwargs)
-        self._executor = SingleThreadedExecutor()
-        self._executor.add_node(self)
-        self._spinner = threading.Thread(target=self._executor.spin)
-        self._spinner.start()
-
-    def __del__(self):
-        self._executor.shutdown()
-        self._spinner.join()
 
     def get_servers(self):
         """Get the base names that are broadcasting smach states."""
@@ -276,15 +268,6 @@ class IntrospectionServer(Node):
         self._server_name = server_name
         self._state = state
         self._path = path
-
-        self._executor = SingleThreadedExecutor()
-        self._executor.add_node(self)
-        self._spinner = threading.Thread(target=self._executor.spin)
-        self._spinner.start()
-
-    def __del__(self):
-        self._executor.shutdown()
-        self._spinner.join()
 
     def start(self):
         # Construct proxies

--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -65,7 +65,7 @@ class IntrospectionClient(Node):
         initial_status_msg = SmachContainerInitialStatusCmd(
                 path = path,
                 initial_states = initial_states,
-                local_data = bytearray(pickle.dumps(initial_userdata._data, 2)))
+                local_data = base64.b64encode(pickle.dumps(initial_userdata._data, 2)))
 
         # A status message to receive confirmation that the state was set properly
         msg_response = SmachContainerStatus()
@@ -216,7 +216,7 @@ class ContainerProxy():
                     path=path,
                     initial_states=self._container.get_initial_states(),
                     active_states=self._container.get_active_states(),
-                    local_data=bytearray(pickle.dumps(self._container.userdata._data, 2)),
+                    local_data=base64.b64encode(pickle.dumps(self._container.userdata._data, 2)),
                     info=info_str)
             # Publish message
             self._status_pub.publish(state_msg)
@@ -241,7 +241,7 @@ class ContainerProxy():
         if msg.path == self._path:
             if all(s in self._container.get_children() for s in initial_states):
                 ud = smach.UserData()
-                ud._data = pickle.loads(msg.local_data)
+                ud._data = pickle.loads(base64.b64decode(msg.local_data))
                 self._server_node.get_logger().debug("Setting initial state in smach path: '"+self._path+"' to '"+str(initial_states)+"' with userdata: "+str(ud._data))
 
                 # Set the initial state
@@ -270,8 +270,8 @@ class IntrospectionServer(Node):
         self._path = path
 
     def start(self):
-        # Construct proxies
-        self.construct(self._server_name, self._state, self._path)
+            # Construct proxies
+            self.construct(self._server_name, self._state, self._path)
 
     def stop(self):
         for proxy in self._proxies:

--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -270,8 +270,8 @@ class IntrospectionServer(Node):
         self._path = path
 
     def start(self):
-            # Construct proxies
-            self.construct(self._server_name, self._state, self._path)
+        # Construct proxies
+        self.construct(self._server_name, self._state, self._path)
 
     def stop(self):
         for proxy in self._proxies:

--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -2,7 +2,6 @@
 import rclpy
 from rclpy.node import Node
 from rclpy.clock import ROSClock
-from rclpy.executors import SingleThreadedExecutor
 from std_msgs.msg import Header
 
 import base64

--- a/smach_ros/test/introspection_test.py
+++ b/smach_ros/test/introspection_test.py
@@ -6,10 +6,8 @@ import threading
 
 import unittest
 
-from smach import *
-from smach_ros import *
-
-from smach_msgs.msg import *
+from smach import StateMachine, UserData
+from smach_ros import RosState, IntrospectionServer, IntrospectionClient
 
 ### Custom state classe
 class Setter(RosState):
@@ -110,9 +108,11 @@ class TestIntrospection(unittest.TestCase):
         node.get_logger().info("Client destroyed")
         intro_server.destroy_node()
         node.get_logger().info("Server destroyed")
-        #executor.shutdown()
-        #spinner.join()
+
+        executor.shutdown()
         node.destroy_node()
+        spinner.join()
+
 
 def main():
     rclpy.init()


### PR DESCRIPTION
On behalf of @RichardK 

- don't spin inside the node, let the outside user determine how to spin this node and how to catch exceptions properly
- Fix encoding/ decoding of user_data messages. This most likely also fixes the "set as initial state" button in the smach_viewer
- updated test accordingly
- set_initial_state was called inside a callback, so rate.sleep() is replaced by time.sleep() (see rate docs)

These changes are verified on running robots together with: #116 