### PR TITLE
[ros2] fix SyntaxWarning 'is not' when checking for equality

### DIFF
--- a/smach/smach/state_machine.py
+++ b/smach/smach/state_machine.py
@@ -74,7 +74,7 @@ class StateMachine(smach.container.Container):
 
     ### Getter and Setter to allow pickling and unpickling state machines
     def __getstate__(self):
-        return {k:v for (k, v) in self.__dict__.items() if k is not "_state_transitioning_lock"}
+        return {k:v for (k, v) in self.__dict__.items() if k != "_state_transitioning_lock"}
 
     def __setstate__(self, d):
         self.__dict__ = d


### PR DESCRIPTION
Forward port https://github.com/ros/executive_smach/pull/97 to ros2 branch